### PR TITLE
fix: class prototype is read only

### DIFF
--- a/src/template7.js
+++ b/src/template7.js
@@ -364,7 +364,7 @@ class Template7 {
   }
 }
 
-Template7.prototype = {
+Object.assign(Template7.prototype, {
   options: {},
   partials: {},
   helpers: {
@@ -502,7 +502,8 @@ Template7.prototype = {
       return options.inverse(this, options.data);
     },
   },
-};
+});
+
 Template7.prototype.helpers.js_compare = Template7.prototype.helpers.js_if;
 function t7(template, data) {
   if (arguments.length === 2) {


### PR DESCRIPTION
Trying webpack 3 with the 2.x.beta version of Framework7 (I know that's not stable released yet :D). It seems we cannot override a Class prototype. instead, we can extend its prototype using Object.assign. This PR does the same.

Also related StackOverflow question: https://stackoverflow.com/questions/45955494/cannot-assign-to-read-only-property-prototype-of-function-class-template7

