### PR TITLE
Fix for parseJsVariable & parseJsParents

### DIFF
--- a/dist/template7.js
+++ b/dist/template7.js
@@ -226,7 +226,7 @@ var Template7Utils = {
     return blocks;
   },
   parseJsVariable: function parseJsVariable(expression, replace, object) {
-	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+	  return expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
 		  if(!part) {
 			  return arr;
 		  }
@@ -256,7 +256,7 @@ var Template7Utils = {
 	  }, []).join('');
   },
   parseJsParents: function parseJsParents(expression, parents) {
-	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+	  return expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
 		  if(!part) {
 			  return arr;
 		  }

--- a/dist/template7.js
+++ b/dist/template7.js
@@ -226,38 +226,64 @@ var Template7Utils = {
     return blocks;
   },
   parseJsVariable: function parseJsVariable(expression, replace, object) {
-    return expression.split(/([+ \-*/^])/g).map(function (part) {
-      if (part.indexOf(replace) < 0) { return part; }
-      if (!object) { return JSON.stringify(''); }
-      var variable = object;
-      if (part.indexOf((replace + ".")) >= 0) {
-        part.split((replace + "."))[1].split('.').forEach(function (partName) {
-          if (partName in variable) { variable = variable[partName]; }
-          else { variable = undefined; }
-        });
-      }
-      if (typeof variable === 'string') {
-        variable = JSON.stringify(variable);
-      }
-      if (variable === undefined) { variable = 'undefined'; }
-      return variable;
-    }).join('');
+	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+		  if(!part) {
+			  return arr;
+		  }
+		  if(part.indexOf(replace) < 0) {
+			  arr.push(part);
+			  return arr;
+		  }
+		  if(!object) {
+			  arr.push(JSON.stringify(''));
+			  return arr;
+		  }
+
+		  var variable = object;
+		  if (part.indexOf((replace + ".")) >= 0) {
+			  part.split((replace + "."))[1].split('.').forEach(function (partName) {
+				  if (partName in variable) variable = variable[partName];
+				  else variable = undefined;
+			  });
+		  }
+		  if (typeof variable === 'string') {
+			  variable = JSON.stringify(variable);
+		  }
+		  if (variable === undefined) variable = 'undefined';
+
+		  arr.push(variable);
+		  return arr;
+	  }, []).join('');
   },
   parseJsParents: function parseJsParents(expression, parents) {
-    return expression.split(/([+ \-*^])/g).map(function (part) {
-      if (part.indexOf('../') < 0) { return part; }
-      if (!parents || parents.length === 0) { return JSON.stringify(''); }
-      var levelsUp = part.split('../').length - 1;
-      var parentData = levelsUp > parents.length ? parents[parents.length - 1] : parents[levelsUp - 1];
+	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+		  if(!part) {
+			  return arr;
+		  }
 
-      var variable = parentData;
-      var parentPart = part.replace(/..\//g, '');
-      parentPart.split('.').forEach(function (partName) {
-        if (variable[partName]) { variable = variable[partName]; }
-        else { variable = 'undefined'; }
-      });
-      return JSON.stringify(variable);
-    }).join('');
+		  if(part.indexOf('../') < 0) {
+			  arr.push(part);
+			  return arr;
+		  }
+
+		  if (!parents || parents.length === 0) {
+			  arr.push(JSON.stringify(''));
+			  return arr;
+		  }
+
+		  var levelsUp = part.split('../').length - 1;
+		  var parentData = levelsUp > parents.length ? parents[parents.length - 1] : parents[levelsUp - 1];
+
+		  var variable = parentData;
+		  var parentPart = part.replace(/..\//g, '');
+		  parentPart.split('.').forEach(function (partName) {
+			  if (variable[partName]) { variable = variable[partName]; }
+			  else { variable = 'undefined'; }
+		  });
+
+		  arr.push(JSON.stringify(variable));
+		  return arr;
+	  }, []).join('');
   },
   getCompileVar: function getCompileVar(name, ctx, data) {
     if ( data === void 0 ) data = 'data_1';

--- a/src/utils.js
+++ b/src/utils.js
@@ -196,38 +196,64 @@ const Template7Utils = {
     return blocks;
   },
   parseJsVariable(expression, replace, object) {
-    return expression.split(/([+ \-*/^])/g).map((part) => {
-      if (part.indexOf(replace) < 0) return part;
-      if (!object) return JSON.stringify('');
-      let variable = object;
-      if (part.indexOf(`${replace}.`) >= 0) {
-        part.split(`${replace}.`)[1].split('.').forEach((partName) => {
-          if (partName in variable) variable = variable[partName];
-          else variable = undefined;
-        });
-      }
-      if (typeof variable === 'string') {
-        variable = JSON.stringify(variable);
-      }
-      if (variable === undefined) variable = 'undefined';
-      return variable;
-    }).join('');
+	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+		  if(!part) {
+			  return arr;
+		  }
+		  if(part.indexOf(replace) < 0) {
+			  arr.push(part);
+			  return arr;
+		  }
+		  if(!object) {
+			  arr.push(JSON.stringify(''));
+			  return arr;
+		  }
+
+		  let variable = object;
+		  if (part.indexOf(`${replace}.`) >= 0) {
+			  part.split(`${replace}.`)[1].split('.').forEach((partName) => {
+				  if (partName in variable) variable = variable[partName];
+				  else variable = undefined;
+			  });
+		  }
+		  if (typeof variable === 'string') {
+			  variable = JSON.stringify(variable);
+		  }
+		  if (variable === undefined) variable = 'undefined';
+
+		  arr.push(variable);
+		  return arr;
+	  }, []).join('');
   },
   parseJsParents(expression, parents) {
-    return expression.split(/([+ \-*^])/g).map((part) => {
-      if (part.indexOf('../') < 0) return part;
-      if (!parents || parents.length === 0) return JSON.stringify('');
-      const levelsUp = part.split('../').length - 1;
-      const parentData = levelsUp > parents.length ? parents[parents.length - 1] : parents[levelsUp - 1];
+	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+		  if(!part) {
+			  return arr;
+		  }
 
-      let variable = parentData;
-      const parentPart = part.replace(/..\//g, '');
-      parentPart.split('.').forEach((partName) => {
-        if (variable[partName]) variable = variable[partName];
-        else variable = 'undefined';
-      });
-      return JSON.stringify(variable);
-    }).join('');
+		  if(part.indexOf('../') < 0) {
+			  arr.push(part);
+			  return arr;
+		  }
+
+		  if (!parents || parents.length === 0) {
+			  arr.push(JSON.stringify(''));
+			  return arr;
+		  }
+
+		  const levelsUp = part.split('../').length - 1;
+		  const parentData = levelsUp > parents.length ? parents[parents.length - 1] : parents[levelsUp - 1];
+
+		  let variable = parentData;
+		  const parentPart = part.replace(/..\//g, '');
+		  parentPart.split('.').forEach((partName) => {
+			  if (variable[partName]) variable = variable[partName];
+			  else variable = 'undefined';
+		  });
+
+		  arr.push(JSON.stringify(variable));
+		  return arr;
+	  }, []).join('');
   },
   getCompileVar(name, ctx, data = 'data_1') {
     let variable = ctx;

--- a/src/utils.js
+++ b/src/utils.js
@@ -196,7 +196,7 @@ const Template7Utils = {
     return blocks;
   },
   parseJsVariable(expression, replace, object) {
-	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+	  return expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
 		  if(!part) {
 			  return arr;
 		  }
@@ -226,7 +226,7 @@ const Template7Utils = {
 	  }, []).join('');
   },
   parseJsParents(expression, parents) {
-	  return.expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
+	  return expression.split(/([+ \-*/^()&=|<>!%:?])/g).reduce(function(arr, part) {
 		  if(!part) {
 			  return arr;
 		  }


### PR DESCRIPTION
new Regexp for first split in parseJsVariable & parseJsParents
now it correct with templates, like:
`{{#js_if "(this.a<@root.some_var)"}}`
works fine, without spaces around `@root.some_var`!

also `map` changed to `reduce` function, to drop empty strings at a first run

PS: please, sorry for using tabs ...